### PR TITLE
Update install.rst

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ Installing prerequisites (this command is for Ubuntu 16.04):
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python python3 libftdi-dev gperf \
                         libboost-program-options-dev autoconf libgmp-dev \
-                        cmake
+                        cmake curl
 
 Yosys, Yosys-SMTBMC and ABC
 ---------------------------


### PR DESCRIPTION
On Ubuntu 20.04, I had to install curl as well:
sudo apt install curl
I guess that would be the same on other setups.