### PR TITLE
Add --anybase option to smtbmc engine

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -231,6 +231,14 @@ the following options:
 +-----------------+---------------------------------------------------------+
 | ``--progress``  | Enable Yosys-SMTBMC timer display.                      |
 +-----------------+---------------------------------------------------------+
+| ``--anybase``   | Generate an arbitrary basecase trace in ``prove`` mode, |
+|                 | instead of one derived from the starting conditions.    |
+|                 | (This provides a weaker proof that there exists some    |
+|                 | basecase for which the assertions hold.                 |
+|                 | This is powerful when combined with a separate proof    |
+|                 | that the assertions hold for ``depth`` cycles after     |
+|                 | reset).                                                 |
++-----------------+---------------------------------------------------------+
 
 Any SMT2 solver that is compatible with ``yosys-smtbmc`` can be passed as
 argument to the ``smtbmc`` engine. The solver options are passed to the solver


### PR DESCRIPTION
This adds an `--anybase` option to the smtbmc engine. When selected, it uses the `-g` smtbmc option (generate an arbitrary trace that passes assertions/assumptions) for the basecase in prove mode, instead of generating a trace from the initial conditions.

This is useful for proofs where the reset state (and thus basecase) of the design does not correspond to the initial state, and can be paired with a separate proof that the assertions hold for `depth` cycles from that reset state. The advantage of this over `--induction` (where the basecase is ignored), is that it guards against vacuous truths where there is no valid basecase, but the induction is still valid.

This is similar to how `equiv_induct` works in yosys (although it proves forwards in time instead of backwards), and proofs with `--anybase` and `equiv_induct` should provide the same result for the same equivalences (assuming other settings are set comparably between the two).

I'm not certain that I have given it the best name but im very happy to take suggestions on what it should be called/exactly how it should work etc.