### PR TITLE
WIP: improve SBY JUnit report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: YosysHQ/setup-oss-cad-suite@v1
       - name: Run checks
-        run: make ci
+        run: tabbypip install xmlschema && make ci

--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -455,57 +455,7 @@ def run_task(taskname):
 
     if not my_opt_tmpdir and not setupmode:
         with open("{}/{}.xml".format(task.workdir, junit_filename), "w") as f:
-            checks = task.design_hierarchy.get_property_list()
-            junit_tests = len(checks)
-            junit_errors = 1 if task.retcode == 16 else 0
-            junit_failures = 0
-            if junit_errors == 0 and task.retcode != 0:
-                if solver_gives_line:
-                    for check in checks:
-                        if check.status == "FAIL":
-                            junit_failures += 1
-            else:
-                junit_failures = 1
-            junit_type = "cover" if task.opt_mode == "cover" else "assert" #should this be here or individual for each check?
-            junit_time = time.strftime('%Y-%m-%dT%H:%M:%S')
-            print(f'<?xml version="1.0" encoding="UTF-8"?>', file=f)
-            print(f'<testsuites>', file=f)
-            print(f'<testsuite timestamp="{junit_time}" hostname="{platform.node()}" package="{junit_ts_name}" id="1" name="{junit_tc_name}" tests="{junit_tests}" errors="{junit_errors}" failures="{junit_failures}" time="{task.total_time}" skipped="{junit_tests - junit_failures}">', file=f)
-            print(f'<properties>', file=f)
-            print(f'<property name="os" value="{platform.system()}"/>', file=f)
-            print(f'</properties>', file=f)
-            if task.precise_prop_status:
-                for check in checks:
-                    detail_attrs = f' type="{check.type}" location="{check.location}" id="{check.name}"'
-                    print(f'<testcase classname="{junit_tc_name}" name="Property {check.type} in {check.hierarchy} at {check.location}" time="{task.total_time}"{detail_attrs}>', file=f) # name required
-                    if check.status == "PASS":
-                        pass
-                    elif check.status == "UNKNOWN":
-                        print(f'<skipped />', file=f)
-                    elif check.status == "FAIL":
-                        print(f'<failure type="{check.type}" message="Property in {check.hierarchy} at {check.location} failed. Trace file: {check.tracefile}" />', file=f)
-                    elif check.status == "ERROR":
-                        print(f'<error type="ERROR"/>', file=f) # type mandatory, message optional
-                    print(f'</testcase>', file=f)
-            else:
-                print(f'<testcase classname="{junit_tc_name}" name="" time="{task.total_time}">', file=f) # name required
-                if task.status == "UNKNOWN":
-                    print(f'<skipped />', file=f)
-                elif task.status == "FAIL":
-                    print(f'<failure type="{junit_type}" message="{task.status}" />', file=f)
-                elif task.status == "ERROR":
-                    print(f'<error type="ERROR"/>', file=f) # type mandatory, message optional
-                print(f'</testcase>', file=f)
-            print('<system-out>', end="", file=f)
-            with open(f"{task.workdir}/logfile.txt", "r") as logf:
-                for line in logf:
-                    print(line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;"), end="", file=f)
-            print('</system-out>', file=f)
-            print('<system-err>', file=f)
-            #TODO: can we handle errors and still output this file?
-            print('</system-err>', file=f)
-            print(f'</testsuite>', file=f)
-            print(f'</testsuites>', file=f)
+            task.print_junit_result(f, junit_ts_name, junit_tc_name)
 
         with open(f"{task.workdir}/status", "w") as f:
             print(f"{task.status} {task.retcode} {task.total_time}", file=f)

--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -455,7 +455,7 @@ def run_task(taskname):
 
     if not my_opt_tmpdir and not setupmode:
         with open("{}/{}.xml".format(task.workdir, junit_filename), "w") as f:
-            task.print_junit_result(f, junit_ts_name, junit_tc_name)
+            task.print_junit_result(f, junit_ts_name, junit_tc_name, junit_format_strict=False)
 
         with open(f"{task.workdir}/status", "w") as f:
             print(f"{task.status} {task.retcode} {task.total_time}", file=f)

--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -478,7 +478,7 @@ def run_task(taskname):
             print(f'</properties>', file=f)
             if solver_gives_line:
                 for check in checks:
-                    print(f'<testcase classname="{junit_tc_name}" name="" time="{task.total_time}">', file=f) # name required
+                    print(f'<testcase classname="{junit_tc_name}" name="Property {check.type} in {check.hierarchy} at {check.location}" time="{task.total_time}">', file=f) # name required
                     if check.status == "UNKNOWN":
                         print(f'<skipped />', file=f)
                     elif check.status == "FAIL":

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -16,13 +16,13 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-import os, re, sys, signal
+import os, re, sys, signal, platform
 if os.name == "posix":
     import resource, fcntl
 import subprocess
 from shutil import copyfile, copytree, rmtree
 from select import select
-from time import time, localtime, sleep
+from time import time, localtime, sleep, strftime
 from sby_design import SbyProperty, SbyModule, design_hierarchy
 
 all_procs_running = []
@@ -744,3 +744,60 @@ class SbyTask:
         with open(f"{self.workdir}/{self.status}", "w") as f:
             for line in self.summary:
                 print(line, file=f)
+
+    def print_junit_result(self, f, junit_ts_name, junit_tc_name, junit_format_strict=False):
+        junit_errors = 1 if self.retcode == 16 else 0
+        if self.precise_prop_status:
+            checks = self.design_hierarchy.get_property_list()
+            junit_tests = len(checks)
+        else:
+            junit_tests = 1
+        if self.retcode in [0, 16]:
+            junit_failures = 0
+        else:
+            if self.precise_prop_status:
+                for check in checks:
+                    if check.status not in self.expect:
+                        junit_failures += 1
+            else:
+                junit_failures = 1
+        junit_time = strftime('%Y-%m-%dT%H:%M:%S')
+        print(f'<?xml version="1.0" encoding="UTF-8"?>', file=f)
+        print(f'<testsuites>', file=f)
+        print(f'<testsuite timestamp="{junit_time}" hostname="{platform.node()}" package="{junit_ts_name}" id="1" name="{junit_tc_name}" tests="{junit_tests}" errors="{junit_errors}" failures="{junit_failures}" time="{self.total_time}" skipped="{junit_tests - junit_failures}">', file=f)
+        print(f'<properties>', file=f)
+        print(f'<property name="os" value="{platform.system()}"/>', file=f)
+        print(f'</properties>', file=f)
+        if self.precise_prop_status:
+            for check in checks:
+                detail_attrs = '' if junit_format_strict else f' type="{check.type}" location="{check.location}" id="{check.name}"'
+                print(f'<testcase classname="{junit_tc_name}" name="Property {check.type} in {check.hierarchy} at {check.location}" time="{self.total_time}"{detail_attrs}>', file=f) # name required
+                if check.status == "PASS":
+                    pass
+                elif check.status == "UNKNOWN":
+                    print(f'<skipped />', file=f)
+                elif check.status == "FAIL":
+                    print(f'<failure type="{check.type}" message="Property in {check.hierarchy} at {check.location} failed. Trace file: {check.tracefile}" />', file=f)
+                elif check.status == "ERROR":
+                    print(f'<error type="ERROR"/>', file=f) # type mandatory, message optional
+                print(f'</testcase>', file=f)
+        else:
+            junit_type = "assert" if self.opt_mode in ["bmc", "prove"] else self.opt_mode
+            print(f'<testcase classname="{junit_tc_name}" name="{junit_tc_name}" time="{self.total_time}">', file=f) # name required
+            if self.status == "UNKNOWN":
+                print(f'<skipped />', file=f)
+            elif self.status == "FAIL":
+                print(f'<failure type="{junit_type}" message="{self.status}" />', file=f)
+            elif self.status == "ERROR":
+                print(f'<error type="ERROR"/>', file=f) # type mandatory, message optional
+            print(f'</testcase>', file=f)
+        print('<system-out>', end="", file=f)
+        with open(f"{self.workdir}/logfile.txt", "r") as logf:
+            for line in logf:
+                print(line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;"), end="", file=f)
+        print('</system-out>', file=f)
+        print('<system-err>', file=f)
+        #TODO: can we handle errors and still output this file?
+        print('</system-err>', file=f)
+        print(f'</testsuite>', file=f)
+        print(f'</testsuites>', file=f)

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -756,6 +756,7 @@ class SbyTask:
             junit_failures = 0
         else:
             if self.precise_prop_status:
+                junit_failures = 0
                 for check in checks:
                     if check.status not in self.expect:
                         junit_failures += 1
@@ -777,7 +778,8 @@ class SbyTask:
                 elif check.status == "UNKNOWN":
                     print(f'<skipped />', file=f)
                 elif check.status == "FAIL":
-                    print(f'<failure type="{check.type}" message="Property in {check.hierarchy} at {check.location} failed. Trace file: {check.tracefile}" />', file=f)
+                    traceinfo = f' Trace file: {check.tracefile}' if check.type == check.Type.ASSERT else ''
+                    print(f'<failure type="{check.type}" message="Property {check.type} in {check.hierarchy} at {check.location} failed.{traceinfo}" />', file=f)
                 elif check.status == "ERROR":
                     print(f'<error type="ERROR"/>', file=f) # type mandatory, message optional
                 print(f'</testcase>', file=f)

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -407,7 +407,9 @@ class SbyTask:
             proc.checkretcode = True
 
             def instance_hierarchy_callback(retcode):
-                assert retcode == 0
+                if retcode != 0:
+                    self.precise_prop_status = False
+                    return
                 if self.design_hierarchy == None:
                     with open(f"{self.workdir}/model/design.json") as f:
                         self.design_hierarchy = design_hierarchy(f)
@@ -776,6 +778,8 @@ class SbyTask:
         print(f'<testsuite timestamp="{junit_time}" hostname="{platform.node()}" package="{junit_ts_name}" id="0" name="{junit_tc_name}" tests="{junit_tests}" errors="{junit_errors}" failures="{junit_failures}" time="{self.total_time}" skipped="{junit_skipped}">', file=f)
         print(f'<properties>', file=f)
         print(f'<property name="os" value="{platform.system()}"/>', file=f)
+        print(f'<property name="expect" value="{", ".join(self.expect)}"/>', file=f)
+        print(f'<property name="status" value="{self.status}"/>', file=f)
         print(f'</properties>', file=f)
         if self.precise_prop_status:
             for check in checks:

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -773,7 +773,7 @@ class SbyTask:
             junit_skipped = 0
         print(f'<?xml version="1.0" encoding="UTF-8"?>', file=f)
         print(f'<testsuites>', file=f)
-        print(f'<testsuite timestamp="{junit_time}" hostname="{platform.node()}" package="{junit_ts_name}" id="1" name="{junit_tc_name}" tests="{junit_tests}" errors="{junit_errors}" failures="{junit_failures}" time="{self.total_time}" skipped="{junit_skipped}">', file=f)
+        print(f'<testsuite timestamp="{junit_time}" hostname="{platform.node()}" package="{junit_ts_name}" id="0" name="{junit_tc_name}" tests="{junit_tests}" errors="{junit_errors}" failures="{junit_failures}" time="{self.total_time}" skipped="{junit_skipped}">', file=f)
         print(f'<properties>', file=f)
         print(f'<property name="os" value="{platform.system()}"/>', file=f)
         print(f'</properties>', file=f)

--- a/sbysrc/sby_design.py
+++ b/sbysrc/sby_design.py
@@ -51,7 +51,7 @@ class SbyProperty:
     tracefile: str = field(default="")
 
     def __repr__(self):
-        return f"SbyProperty<{self.type} {self.name} at {self.location}: status={self.status}, tracefile=\"{self.tracefile}\""
+        return f"SbyProperty<{self.type} {self.name} at {self.location}: status={self.status}, tracefile=\"{self.tracefile}\">"
 
 @dataclass
 class SbyModule:
@@ -105,14 +105,15 @@ def design_hierarchy(filename):
 
         cells = design_json["modules"][module_name]["cells"]
         for cell_name, cell in cells.items():
+            sub_hierarchy=f"{hierarchy}/{instance_name}" if hierarchy else instance_name
             if cell["type"][0] != '$':
-                mod.submodules[cell_name] = make_mod_hier(cell_name, cell["type"], hierarchy=f"{hierarchy}/{instance_name}")
+                mod.submodules[cell_name] = make_mod_hier(cell_name, cell["type"], hierarchy=sub_hierarchy)
             if cell["type"] in ["$assume", "$assert", "$cover", "$live"]:
                 try:
                     location = cell["attributes"]["src"]
                 except KeyError:
                     location = ""
-                p = SbyProperty(name=cell_name, type=SbyProperty.Type.from_cell(cell["type"]), location=location, hierarchy=f"{hierarchy}/{instance_name}")
+                p = SbyProperty(name=cell_name, type=SbyProperty.Type.from_cell(cell["type"]), location=location, hierarchy=sub_hierarchy)
                 mod.properties.append(p)
         return mod
 

--- a/sbysrc/sby_design.py
+++ b/sbysrc/sby_design.py
@@ -1,0 +1,102 @@
+#
+# SymbiYosys (sby) -- Front-end for Yosys-based formal verification flows
+#
+# Copyright (C) 2022  N. Engelhardt <nak@yosyshq.com>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import json
+from enum import Enum, auto
+from dataclasses import dataclass, field
+
+@dataclass
+class SbyProperty:
+    class Type(Enum):
+        ASSUME = auto()
+        ASSERT = auto()
+        COVER = auto()
+        LIVE = auto()
+
+        def __repr__(self):
+            return self.name
+
+        @classmethod
+        def from_cell(c, name):
+            if name == "$assume":
+                return c.ASSUME
+            if name == "$assert":
+                return c.ASSERT
+            if name == "$cover":
+                return c.COVER
+            if name == "$live":
+                return c.LIVE
+            raise ValueError("Unknown property type: " + name)
+
+    name: str
+    type: Type
+    location: str
+    hierarchy: str
+    status: str = field(default="UNKNOWN")
+    tracefile: str = field(default="")
+
+@dataclass
+class SbyModule:
+    name: str
+    type: str
+    submodules: dict = field(default_factory=dict)
+    properties: list = field(default_factory=list)
+
+    def get_property_list(self):
+        l = list()
+        l.extend(self.properties)
+        for submod in self.submodules:
+            l.extend(submod.get_property_list())
+        return l
+
+def design_hierarchy(filename):
+    design_json = json.load(filename)
+    def make_mod_hier(instance_name, module_name, hierarchy=""):
+        # print(instance_name,":", module_name)
+        mod = SbyModule(name=instance_name, type=module_name)
+
+        cells = design_json["modules"][module_name]["cells"]
+        for cell_name, cell in cells.items():
+            if cell["type"][0] != '$':
+                mod.submodules[cell_name] = make_mod_hier(cell_name, cell["type"], hierarchy=f"{hierarchy}/{instance_name}")
+            if cell["type"] in ["$assume", "$assert", "$cover", "$live"]:
+                try:
+                    location = cell["attributes"]["src"]
+                except KeyError:
+                    location = ""
+                p = SbyProperty(name=cell_name, type=SbyProperty.Type.from_cell(cell["type"]), location=location, hierarchy=f"{hierarchy}/{instance_name}")
+                mod.properties.append(p)
+        return mod
+
+    for module_name in design_json["modules"]:
+        attrs = design_json["modules"][module_name]["attributes"]
+        if "top" in attrs and int(attrs["top"]) == 1:
+            hierarchy = make_mod_hier(module_name, module_name)
+            return hierarchy
+    else:
+        raise ValueError("Cannot find top module")
+
+def main():
+    import sys
+    if len(sys.argv) != 2:
+        print(f"""Usage: {sys.argv[0]} design.json""")
+    with open(sys.argv[1]) as f:
+        print(design_hierarchy(f))
+
+if __name__ == '__main__':
+    main()

--- a/sbysrc/sby_engine_smtbmc.py
+++ b/sbysrc/sby_engine_smtbmc.py
@@ -201,6 +201,12 @@ def run(mode, task, engine_idx, engine):
             last_prop.tracefile = match[1]
             last_prop = None
 
+        match = re.match(r"^## [0-9: ]+ Unreached cover statement at (\S+) \((\S+)\).", line)
+        if match:
+            cell_name = match[2]
+            prop = task.design_hierarchy.find_property_by_cellname(cell_name)
+            prop.status = "FAIL"
+
         return line
 
     def exit_callback(retcode):

--- a/sbysrc/sby_engine_smtbmc.py
+++ b/sbysrc/sby_engine_smtbmc.py
@@ -273,6 +273,9 @@ def run(mode, task, engine_idx, engine):
                 assert False
 
             if task.basecase_pass and task.induction_pass:
+                for prop in task.design_hierarchy:
+                    if prop.type == prop.Type.ASSERT and prop.status == "UNKNOWN":
+                        prop.status = "PASS"
                 task.update_status("PASS")
                 task.summary.append("successful proof by k-induction.")
                 task.terminate()

--- a/sbysrc/sby_engine_smtbmc.py
+++ b/sbysrc/sby_engine_smtbmc.py
@@ -143,7 +143,7 @@ def run(mode, task, engine_idx, engine):
         task,
         procname,
         task.model(model_name),
-        f"""cd {task.workdir}; {task.exe_paths["smtbmc"]} {" ".join(smtbmc_opts)} -t {t_opt} {random_seed} --append {task.opt_append} --cellinfo --dump-vcd {trace_prefix}.vcd --dump-vlogtb {trace_prefix}_tb.v --dump-smtc {trace_prefix}.smtc model/design_{model_name}.smt2""",
+        f"""cd {task.workdir}; {task.exe_paths["smtbmc"]} {" ".join(smtbmc_opts)} -t {t_opt} {random_seed} --append {task.opt_append} --dump-vcd {trace_prefix}.vcd --dump-vlogtb {trace_prefix}_tb.v --dump-smtc {trace_prefix}.smtc model/design_{model_name}.smt2""",
         logfile=open(logfile_prefix + ".txt", "w"),
         logstderr=(not progress)
     )
@@ -195,11 +195,13 @@ def run(mode, task, engine_idx, engine):
             prop = task.design_hierarchy.find_property_by_cellname(cell_name)
             prop.status = "PASS"
             last_prop = prop
+            return line
 
         match = re.match(r"^## [0-9: ]+ Writing trace to VCD file: (\S+)", line)
         if match and last_prop:
             last_prop.tracefile = match[1]
             last_prop = None
+            return line
 
         match = re.match(r"^## [0-9: ]+ Unreached cover statement at (\S+) \((\S+)\).", line)
         if match:

--- a/tests/JUnit.xsd
+++ b/tests/JUnit.xsd
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:choice minOccurs="0">
+						<xs:element name="skipped" />
+						<xs:element name="error" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="failure">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skipped" type="xs:int" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/tests/JUnit.xsd
+++ b/tests/JUnit.xsd
@@ -130,6 +130,26 @@ Permission to waive conditions of this license may be requested from Windy Road 
 							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
+					<xs:attribute name="id" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Cell ID of the property</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="type" type="xs:token" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Kind of property (assert, cover, live)</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="location" type="xs:token" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Source location of the property</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="tracefile" type="xs:token" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Tracefile for the property</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="system-out">

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,4 +14,4 @@ test_%: %.sby FORCE
 	python3 ../sbysrc/sby.py -f $<
 
 $(JUNIT_TESTS): $(SBY_TESTS)
-	python validate_junit.py $@/$@.xml
+	python3 validate_junit.py $@/$@.xml

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,17 @@
 SBY_FILES=$(wildcard *.sby)
 SBY_TESTS=$(addprefix test_,$(SBY_FILES:.sby=))
+JUNIT_TESTS=junit_assert_pass junit_assert_fail junit_assert_preunsat \
+junit_cover_pass junit_cover_uncovered junit_cover_assert junit_cover_preunsat \
+junit_timeout_error_timeout junit_timeout_error_syntax junit_timeout_error_solver
 
-.PHONY: test
+.PHONY: test validate_junit
 
 FORCE:
 
-test: $(SBY_TESTS)
+test: $(JUNIT_TESTS)
 
 test_%: %.sby FORCE
 	python3 ../sbysrc/sby.py -f $<
+
+$(JUNIT_TESTS): $(SBY_TESTS)
+	python validate_junit.py $@/$@.xml

--- a/tests/both_ex.sby
+++ b/tests/both_ex.sby
@@ -15,7 +15,7 @@ pono: btor pono
 cover: btor btormc
 
 [script]
-read_verilog -sv both_ex.v
+read -sv both_ex.v
 prep -top test
 
 [files]

--- a/tests/cover_fail.sby
+++ b/tests/cover_fail.sby
@@ -25,7 +25,7 @@ if (rst)
 else
   count <= count + 1'b1;
 
-cover (count == 0);
-cover (count == 4'd11);
+cover (count == 0 && !rst);
+cover (count == 4'd11 && !rst);
 end
 endmodule

--- a/tests/cover_fail.sby
+++ b/tests/cover_fail.sby
@@ -7,7 +7,7 @@ expect fail
 smtbmc boolector
 
 [script]
-read_verilog -sv test.v
+read -sv test.v
 prep -top test
 
 [file test.v]

--- a/tests/cover_fail.sby
+++ b/tests/cover_fail.sby
@@ -1,7 +1,7 @@
 [options]
 mode cover
 depth 5
-expect fail
+expect pass,fail
 
 [engines]
 smtbmc boolector

--- a/tests/cover_fail.sby
+++ b/tests/cover_fail.sby
@@ -1,0 +1,31 @@
+[options]
+mode cover
+depth 5
+expect fail
+
+[engines]
+smtbmc boolector
+
+[script]
+read_verilog -sv test.v
+prep -top test
+
+[file test.v]
+module test(
+input clk,
+input rst,
+output reg [3:0] count
+);
+
+initial assume (rst == 1'b1);
+
+always @(posedge clk) begin
+if (rst)
+  count <= 4'b0;
+else
+  count <= count + 1'b1;
+
+cover (count == 0);
+cover (count == 4'd11);
+end
+endmodule

--- a/tests/junit_assert.sby
+++ b/tests/junit_assert.sby
@@ -1,0 +1,38 @@
+[tasks]
+pass
+fail
+preunsat
+
+[options]
+mode bmc
+depth 1
+
+pass: expect pass
+fail: expect fail
+preunsat: expect error
+
+[engines]
+smtbmc boolector
+
+[script]
+fail: read -define FAIL
+preunsat: read -define PREUNSAT
+read -sv test.sv
+prep -top top
+
+[file test.sv]
+module test(input foo);
+always @* assert(foo);
+`ifdef FAIL
+always @* assert(!foo);
+`endif
+`ifdef PREUNSAT
+always @* assume(!foo);
+`endif
+endmodule
+
+module top();
+test test_i (
+.foo(1'b1)
+);
+endmodule

--- a/tests/junit_cover.sby
+++ b/tests/junit_cover.sby
@@ -1,0 +1,43 @@
+[tasks]
+pass
+uncovered fail
+assert fail
+preunsat
+
+[options]
+mode cover
+depth 1
+
+pass: expect pass
+fail: expect fail
+preunsat: expect fail
+
+[engines]
+smtbmc boolector
+
+[script]
+uncovered: read -define FAIL
+assert: read -define FAIL_ASSERT
+preunsat: read -define PREUNSAT
+read -sv test.sv
+prep -top top
+
+[file test.sv]
+module test(input foo);
+`ifdef PREUNSAT
+always @* assume(!foo);
+`endif
+always @* cover(foo);
+`ifdef FAIL
+always @* cover(!foo);
+`endif
+`ifdef FAIL_ASSERT
+always @* assert(!foo);
+`endif
+endmodule
+
+module top();
+test test_i (
+.foo(1'b1)
+);
+endmodule

--- a/tests/junit_nocodeloc.sby
+++ b/tests/junit_nocodeloc.sby
@@ -1,0 +1,20 @@
+[options]
+mode bmc
+
+expect fail
+
+[engines]
+smtbmc boolector
+
+[script]
+read -sv multi_assert.v
+prep -top test
+setattr -unset src
+
+[file multi_assert.v]
+module test();
+always @* begin
+assert (1);
+assert (0);
+end
+endmodule

--- a/tests/junit_timeout_error.sby
+++ b/tests/junit_timeout_error.sby
@@ -1,0 +1,42 @@
+[tasks]
+syntax error
+solver error
+timeout
+
+[options]
+mode cover
+depth 1
+timeout: timeout 1
+error: expect error
+timeout: expect timeout
+
+[engines]
+~solver: smtbmc --dumpsmt2 --progress --stbv z3
+solver: smtbmc foo
+
+[script]
+read -noverific
+syntax: read -define SYNTAX_ERROR
+read -sv primes.sv
+prep -top primes
+
+[file primes.sv]
+module primes;
+	parameter [8:0] offset = 7;
+	(* anyconst *) reg [8:0] prime1;
+	wire [9:0] prime2 = prime1 + offset;
+	(* allconst *) reg [4:0] factor;
+
+`ifdef SYNTAX_ERROR
+	foo
+`endif
+
+	always @* begin
+		if (1 < factor && factor < prime1)
+			assume ((prime1 % factor) != 0);
+		if (1 < factor && factor < prime2)
+			assume ((prime2 % factor) != 0);
+		assume (1 < prime1);
+		cover (1);
+	end
+endmodule

--- a/tests/multi_assert.sby
+++ b/tests/multi_assert.sby
@@ -12,7 +12,7 @@ btormc: btor btormc
 pono: btor pono
 
 [script]
-read_verilog -sv multi_assert.v
+read -sv multi_assert.v
 prep -top test
 
 [file multi_assert.v]

--- a/tests/preunsat.sby
+++ b/tests/preunsat.sby
@@ -12,7 +12,7 @@ btormc: btor btormc
 yices: smtbmc yices
 
 [script]
-read_verilog -sv test.sv
+read -sv test.sv
 prep -top test
 
 [file test.sv]

--- a/tests/redxor.sby
+++ b/tests/redxor.sby
@@ -6,7 +6,7 @@ expect pass
 btor btormc
 
 [script]
-read_verilog -formal redxor.v
+read -formal redxor.v
 prep -top test
 
 [files]

--- a/tests/stopfirst.sby
+++ b/tests/stopfirst.sby
@@ -6,7 +6,7 @@ expect fail
 btor btormc
 
 [script]
-read_verilog -sv test.sv
+read -sv test.sv
 prep -top test
 
 [file test.sv]

--- a/tests/submod_props.sby
+++ b/tests/submod_props.sby
@@ -12,7 +12,7 @@ expect fail
 smtbmc boolector
 
 [script]
-read_verilog -sv test.sv
+read -sv test.sv
 prep -top top
 
 [file test.sv]

--- a/tests/submod_props.sby
+++ b/tests/submod_props.sby
@@ -1,0 +1,30 @@
+[tasks]
+bmc
+cover
+
+[options]
+bmc: mode bmc
+cover: mode cover
+
+expect fail
+
+[engines]
+smtbmc boolector
+
+[script]
+read_verilog -sv test.sv
+prep -top top
+
+[file test.sv]
+module test(input foo);
+always @* assert(foo);
+always @* assert(!foo);
+always @* cover(foo);
+always @* cover(!foo);
+endmodule
+
+module top();
+test test_i (
+.foo(1'b1)
+);
+endmodule

--- a/tests/validate_junit.py
+++ b/tests/validate_junit.py
@@ -1,0 +1,19 @@
+from xmlschema import XMLSchema, XMLSchemaValidationError
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate JUnit output")
+    parser.add_argument('xml')
+    parser.add_argument('--xsd', default="JUnit.xsd")
+
+    args = parser.parse_args()
+
+    schema = XMLSchema(args.xsd)
+    try:
+        schema.validate(args.xml)
+    except XMLSchemaValidationError as e:
+        print(e)
+        exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Steps for improved JUnit reports:

- [ ] Yosys pass to export list of assert/assume/cover statements (https://github.com/YosysHQ/yosys/pull/3083/) This is currently using the old json export.
- [x] Import list of properties (store in SbyJob, where engines can access it)
- [x] Update status of individual properties based on solver output (requires https://github.com/YosysHQ/yosys/pull/3186)
- [x] Print per-property testcase elements in JUnit report
- [x] Add tests that validate JUnit reports

Builds are failing until https://github.com/YosysHQ/yosys/pull/3186 is merged.