### PR TITLE
Regression test: do not merge FFs with unconstrained initvals

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -12,4 +12,5 @@
 /submod_props*/
 /multi_assert*/
 /aim_vs_smt2_nonzero_start_offset*/
+/invalid_ff_dcinit_merge*/
 /2props1trace*/

--- a/tests/invalid_ff_dcinit_merge.sby
+++ b/tests/invalid_ff_dcinit_merge.sby
@@ -1,0 +1,29 @@
+[options]
+mode bmc
+depth 4
+expect fail
+
+[engines]
+smtbmc
+
+[script]
+read -formal top.sv
+prep -top top
+
+[file top.sv]
+module top(
+input clk, d
+);
+
+reg q1;
+reg q2;
+
+always @(posedge clk) begin
+    q1 <= d;
+    q2 <= d;
+end;
+
+// q1 and q2 are unconstrained in the initial state, so this should fail
+always @(*) assert(q1 == q2);
+
+endmodule


### PR DESCRIPTION
Currently done by `opt -keepdc` via `opt_merge` but not valid in a
formal context.

Test will fail until a yosys fix (in progress) lands.