### PR TITLE
examples: Fix use of SVA value change expressions

### DIFF
--- a/docs/examples/multiclk/dpmem.sv
+++ b/docs/examples/multiclk/dpmem.sv
@@ -47,9 +47,9 @@ module top (
 	(* gclk *) reg gclk;
 
 	always @(posedge gclk) begin
-		assume ($stable(rc) || $stable(wc));
-
 		if (!init) begin
+			assume ($stable(rc) || $stable(wc));
+
 			if ($rose(rc) && shadow_valid && shadow_addr == $past(ra)) begin
 				assert (shadow_data == rd);
 			end


### PR DESCRIPTION
The $stable value change expression cannot be true for a non-x signal in
the initial state. This is now correctly handled by the verific import,
so the dpmem example needs to start assuming `$stable` only after
leaving the initial state.