### PR TITLE
tests: Remove unused tool list in test Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,23 +2,6 @@ test:
 
 .PHONY: test clean refresh help
 
-TOOL_LIST := \
-	btorsim \
-	yices \
-	aigbmc \
-	avy \
-	bitwuzla \
-	boolector \
-	btormc \
-	cvc4 \
-	mathsat \
-	pono \
-	suprove \
-	yices-smt2 \
-	yices \
-	yosys-abc \
-	z3
-
 help:
 	@cat make/help.txt
 


### PR DESCRIPTION
The checks for available tools moved to a python script, so need need to have a copy of the tool list in the Makefile.