### PR TITLE
smtbmc: Fix induction trace filename with --keep-going for the basecase

### DIFF
--- a/sbysrc/sby_engine_smtbmc.py
+++ b/sbysrc/sby_engine_smtbmc.py
@@ -131,7 +131,7 @@ def run(mode, task, engine_idx, engine):
         smtbmc_opts.append("-c")
         trace_prefix += "%"
 
-    if keep_going:
+    if keep_going and mode != "prove_induction":
         smtbmc_opts.append("--keep-going")
         trace_prefix += "%"
 


### PR DESCRIPTION
--keep-going only applies to the basecase and induction runs without that
option, so the trace filename for induction should have no placeholder.