### PR TITLE
Use default prefix directory when no task is specified

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -402,7 +402,10 @@ def run_task(taskname):
     if workdir is not None:
         my_workdir = workdir
     elif workdir_prefix is not None:
-        my_workdir = workdir_prefix + "_" + taskname
+        if taskname is None:
+            my_workdir = workdir_prefix
+        else:
+            my_workdir = workdir_prefix + "_" + taskname
 
     if my_workdir is None and sbyfile is not None and not my_opt_tmpdir:
         my_workdir = sbyfile[:-4]


### PR DESCRIPTION
At the moment if you use `sby --prefix some/path sbyfile.sby` and the sby file has only an implicit task, `taskname` is None so an exception is raised when `taskname` is used to calculate the workdir. `-d <dirname>` can be used for this purpose, but when invoking sby scripts from a build system/other scripting it is inconvenient to have to know whether a sby file contains one or multiple tasks and separately choose `--prefix` vs `-d`.

This change allows the prefix directory to be used when no taskname is supplied and the task is implicit.

(It may be that i've completely missed a feature of sby that already does this in which case close this)