### PR TITLE
abc pdr: Enable log output by default

### DIFF
--- a/sbysrc/sby_engine_abc.py
+++ b/sbysrc/sby_engine_abc.py
@@ -41,6 +41,7 @@ def run(mode, task, engine_idx, engine):
     elif abc_command[0] == "pdr":
         if mode != "prove":
             task.error("ABC command 'pdr' is only valid in prove mode.")
+        abc_command[0] += f" -v"
 
     else:
         task.error(f"Invalid ABC command {abc_command[0]}.")


### PR DESCRIPTION
This makes it consistent with the other abc solvers and shows whether
abc pdr is making progress.