### PR TITLE
avoid erroring out when coarse-grain logic loops can be resolved by mapping to fine grain operators

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -567,6 +567,7 @@ class SbyTask(SbyConfig):
             os.makedirs(f"{self.workdir}/model")
 
         def print_common_prep(check):
+            print("scc -select; simplemap; select -clear", file=f)
             if self.opt_multiclock:
                 print("clk2fflogic", file=f)
             else:

--- a/tests/regression/fake_loop.sby
+++ b/tests/regression/fake_loop.sby
@@ -1,0 +1,23 @@
+[options]
+mode cover
+
+[engines]
+smtbmc boolector
+
+[script]
+read -formal fake_loop.sv
+hierarchy -top fake_loop
+proc
+
+[file fake_loop.sv]
+module fake_loop(input clk, input a, input b, output [9:0] x);
+    wire [9:0] ripple;
+    reg [9:0] prev_ripple = 9'b0;
+
+    always @(posedge clk) prev_ripple <= ripple;
+
+    assign ripple = {ripple[8:0], a} ^ prev_ripple; // only cyclic at the coarse-grain level
+    assign x = ripple[9] + b;
+
+    always @(posedge clk) cover(ripple[9]);
+endmodule


### PR DESCRIPTION
(all 3 commands are on the same line just in case someone looks at the generated scripts and wants to play around with it, that way it's clear that they need to be used/removed together)