### PR TITLE
git: added vscode directories to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /docs/build
 /sbysrc/demo[0-9]
 /sbysrc/__pycache__
-
+/.vs
+/.vscode


### PR DESCRIPTION
Added the `.vs` and `.vscode` directories to the `.gitignore` to prevent them from accidentally getting committed