### PR TITLE
jobserver: Only poll non-helper-process jobserver fd when ready to read

### DIFF
--- a/sbysrc/sby_jobserver.py
+++ b/sbysrc/sby_jobserver.py
@@ -287,7 +287,7 @@ class SbyJobClient:
     def poll_fds(self):
         if self.helper_process:
             return [self.response_read_fd]
-        elif self.read_fd is not None:
+        elif self.read_fd is not None and self.has_pending_leases():
             return [self.read_fd]
         else:
             return []


### PR DESCRIPTION
This avoids SBY going into a busy wait loop in that case.