### PR TITLE
Do not use fstring syntax that requires Python 3.8

### DIFF
--- a/sbysrc/sby_jobserver.py
+++ b/sbysrc/sby_jobserver.py
@@ -125,7 +125,7 @@ class SbyJobLease:
         self.is_done = True
 
     def __repr__(self):
-        return f"{self.is_ready=} {self.is_done=}"
+        return f"is_ready={self.is_ready} is_done={self.is_done}"
 
     def __del__(self):
         self.done()


### PR DESCRIPTION
While we most likely will require Python 3.8 going forward, this might restore Python 3.6 compatibility until we update the installation guide.