### PR TITLE
append_assume: Make `append_assume on` the default for now

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -192,7 +192,7 @@ options are:
 |                   | ``prove``, | the trace. Depending on the engine and options used     |
 |                   | ``cover``  | this may be implicitly on or not supported (as          |
 |                   |            | indicated in SBY's log output).                         |
-|                   |            | Values: ``on``, ``off``. Default: ``off``               |
+|                   |            | Values: ``on``, ``off``. Default: ``on``                |
 +-------------------+------------+---------------------------------------------------------+
 
 Engines section

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -1238,7 +1238,7 @@ class SbyTask(SbyConfig):
 
         if self.opt_mode != "live":
             self.handle_int_option("append", 0)
-            self.handle_bool_option("append_assume", False)
+            self.handle_bool_option("append_assume", True)
 
         self.handle_str_option("make_model", None)
 


### PR DESCRIPTION
Having `append_assume off` needs `vcd_sim on` to not be ignored with a warning and `vcd_sim off` is still the default.