### PR TITLE
Add sphinx-argparse to generate usage

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import sys
+import os
+
 project = 'YosysHQ SBY'
 author = 'YosysHQ GmbH'
 copyright = '2023 YosysHQ GmbH'
@@ -40,3 +43,5 @@ html_theme_options = {
 
 extensions = ['sphinx.ext.autosectionlabel']
 extensions += ['sphinxarg.ext']
+
+sys.path.append(os.path.abspath(f"{__file__}/../../../sbysrc"))

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -6,6 +6,6 @@ one of the available CAD suites, it can be called as follows.  Note that this in
 available via `sby --help`.  For more information on installation, see :ref:`install-doc`.
 
 .. argparse::
-    :filename: ../sbysrc/sby_cmdline.py
+    :module: sby_cmdline
     :func: parser_func
     :prog: sby


### PR DESCRIPTION
Move parser generation into a seperate file to avoid import issues with bad python modules during docs gen. With the requirements.txt provided to readthedocs, there shouldn't need to be any other changes? Also I've never been able to run `make test` so I'm not actually sure if the changes break sby, but they shouldn't.