### PR TITLE
Fix PREFIX in makefile to accept environment variable, if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 DESTDIR =
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 PROGRAM_PREFIX =
 
 # On Windows, manually setting absolute path to Python binary may be required


### PR DESCRIPTION
This is the makefile fix to allow PREFIX to be set as an environment variable, to allow alternate tool installation,  #253