### PR TITLE
Update sby_engine_abc.py

### DIFF
--- a/sbysrc/sby_engine_abc.py
+++ b/sbysrc/sby_engine_abc.py
@@ -182,7 +182,7 @@ def run(mode, task, engine_idx, engine):
             match = re.match(r"^Output [0-9]+ of miter .* was asserted in frame [0-9]+.", line)
             if match: proc_status = "FAIL"
 
-        match = re.match(r"^Proved output +([0-9]+) in frame +[0-9]+", line)
+        match = re.match(r"^Proved output +([0-9]+) in frame +-?[0-9]+", line)
         if match:
             output = int(match[1])
             prop = aiger_props[output]


### PR DESCRIPTION
ABC will sometimes return negative frame numbers when proving by convergence, e.g.
```
engine_0: Proved output 1 in frame -698905656 (converged).
engine_0: Proved output 4 in frame -698905656 (converged).
```
This change fixes these properties being missed and causing the engine status to return UNKNOWN due to `proved_count != len(proved)`.