### PR TITLE
Fixes issue #269 by removing an erroneous "if sbyfile" check.

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -422,8 +422,7 @@ def start_task(taskloop, taskname):
 
         if opt_force and not reusedir:
             early_log(my_workdir, f"Removing directory '{os.path.abspath(my_workdir)}'.")
-            if sbyfile:
-                shutil.rmtree(my_workdir, ignore_errors=True)
+            shutil.rmtree(my_workdir, ignore_errors=True)
 
         if reusedir:
             pass


### PR DESCRIPTION
This commit removes an erroneous "if sbyfile" that would turn '-f' into a no-op for stdin input files. Presumably this check was originally intended to handle the case of stdin input file and no specified workdir (which uses a temporary workdir). In the current version the check is redundant for this particular case. The check is erroneous in the case of stdin input file and a specified workdir, so we simply remove the check.