### PR TITLE
Add --version option based on git describe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.gittag export-subst

--- a/.gittag
+++ b/.gittag
@@ -1,0 +1,1 @@
+$Format:%(describe)$

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ ifeq ($(OS), Windows_NT)
 PYTHON = $(shell cygpath -w -m $(PREFIX)/bin/python3)
 endif
 
+ifeq ($(file < .gittag),$$Format:%(describe)$$)
+YOSYS_RELEASE_VERSION := SBY $(shell git describe --dirty)
+else
+YOSYS_RELEASE_VERSION := SBY $(file < .gittag)
+endif
+
 .PHONY: help install ci test html clean
 
 help:
@@ -38,10 +44,12 @@ install:
 	sed -e 's|##yosys-program-prefix##|"'$(PROGRAM_PREFIX)'"|' < sbysrc/sby_core.py > $(DESTDIR)$(PREFIX)/share/yosys/python3/sby_core.py
 ifeq ($(OS), Windows_NT)
 	sed -e 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' \
+		-e "s|##yosys-release-version##|release_version = '$(YOSYS_RELEASE_VERSION)'|;" \
 		-e "s|#!/usr/bin/env python3|#!$(PYTHON)|" < sbysrc/sby.py > $(DESTDIR)$(PREFIX)/bin/sby-script.py
 	gcc -DGUI=0 -O -s -o $(DESTDIR)$(PREFIX)/bin/sby.exe extern/launcher.c
 else
-	sed 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' < sbysrc/sby.py > $(DESTDIR)$(PREFIX)/bin/sby
+	sed -e 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' \
+		-e "s|##yosys-release-version##|release_version = '$(YOSYS_RELEASE_VERSION)'|;" < sbysrc/sby.py > $(DESTDIR)$(PREFIX)/bin/sby
 	chmod +x $(DESTDIR)$(PREFIX)/bin/sby
 endif
 

--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -25,9 +25,12 @@ from sby_jobserver import SbyJobClient, process_jobserver_environment
 from sby_status import SbyStatusDb
 import time, platform, click
 
+release_version = 'unknown SBY version'
+##yosys-release-version##
+
 process_jobserver_environment()  # needs to be called early
 
-parser = parser_func()
+parser = parser_func(release_version)
 
 args = parser.parse_args()
 

--- a/sbysrc/sby_cmdline.py
+++ b/sbysrc/sby_cmdline.py
@@ -6,7 +6,7 @@ class DictAction(argparse.Action):
         name = option_string.lstrip(parser.prefix_chars).replace("-", "_")
         getattr(namespace, self.dest)[name] = values
 
-def parser_func():
+def parser_func(release_version='unknown SBY version'):
     parser = argparse.ArgumentParser(prog="sby",
             usage="%(prog)s [options] [<jobname>.sby [tasknames] | <dirname>]")
     parser.set_defaults(exe_paths=dict())
@@ -80,5 +80,7 @@ def parser_func():
             help=".sby file OR directory containing config.sby file")
     parser.add_argument("arg_tasknames", metavar="tasknames", nargs="*",
             help="tasks to run (only valid when <jobname>.sby is used)")
+
+    parser.add_argument('--version', action='version', version=release_version)
 
     return parser


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

SBY assumes that it is used together with a compatible yosys version, but does not offer any easy way to tell what that compatible yosys version is. Users of the OSS Cad Suite or Tabby CAD automatically have matching versions, and we create tags corresponding to the yosys version in this repository, but users that manually installed SBY in the past have no way to check which version they installed. This adds a `--version` option that prints the `git describe` output identifying the installed version.

_Explain how this is achieved._

I added a new `##yosys-release-version##` placeholder following `release_version = 'unknown SBY version'` to the source code and updated the makefile to substitute the placeholder with a statement overwriting the `release_version` variable.

I also added a `.gittag` file and ` .gitattribtues` file so git will remember the tagged version when creating source archives.

The makefile first checks the .gittag file and uses that when it includes a version string, falling back to running `git describe --dirty` otherwise.

_If applicable, please suggest to reviewers how they can test the change._

It would be good to check that this works correctly in the context of the OSS Cad Suite builds.