### PR TITLE
docs: fix reference to aigbmc engine option

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -236,7 +236,7 @@ The following mode/engine/solver combinations are currently supported:
 |           |                          |
 |           | ``abc sim3``             |
 |           |                          |
-|           | ``aiger smtbmc``         |
+|           | ``aiger aigbmc``         |
 +-----------+--------------------------+
 | ``prove`` | ``smtbmc [all solvers]`` |
 |           |                          |


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Docs incorrectly referred to engine mode `aiger smtbmc` which doesn't exist, it is actually `aiger aigbmc`
