### PR TITLE
Add support for the imctk-eqy-engine

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -851,6 +851,7 @@ class SbyTask(SbyConfig):
             "avy": os.getenv("AVY", "avy"),
             "btormc": os.getenv("BTORMC", "btormc"),
             "pono": os.getenv("PONO", "pono"),
+            "imctk-eqy-engine": os.getenv("IMCTK_EQY_ENGINE", "imctk-eqy-engine"),
         }
 
         self.taskloop = taskloop or SbyTaskloop()


### PR DESCRIPTION
This is not added to the documentation, as this is currently intended for internal use only.

_What are the reasons/motivation for this change?_

Supporting the imctk-eqy-engine from EQY

_Explain how this is achieved._

The EQY imctk strategy that is about to be added will use this engine to re-use SBY's aiger flow to prepare a miter for equivalence checking.

_If applicable, please suggest to reviewers how they can test the change._

This can be tested with any SBY project that works with the aiger engine, but is intended for equivalence checking miters.