### PR TITLE
fix lookup of mangled path names

### DIFF
--- a/sbysrc/sby_design.py
+++ b/sbysrc/sby_design.py
@@ -146,12 +146,12 @@ class SbyModule:
         path_iter = iter(path)
 
         mod = next(path_iter).translate(trans)
-        if self.name != mod:
+        if self.name.translate(trans) != mod:
             raise ValueError(f"{self.name} is not the first module in hierarchical path {pretty_path(path)}.")
 
         mod_hier = self
         for mod in path_iter:
-            mod_hier = next((v for k, v in mod_hier.submodules.items() if mod == k.translate(trans)), None)
+            mod_hier = next((v for k, v in mod_hier.submodules.items() if mod.translate(trans) == k.translate(trans)), None)
             if not mod_hier:
                 raise KeyError(f"Could not find {pretty_path(path)} in design hierarchy!")
 

--- a/tests/regression/vhdl_hier_path.sby
+++ b/tests/regression/vhdl_hier_path.sby
@@ -1,0 +1,96 @@
+[options]
+mode bmc
+depth 1
+expect fail
+
+[engines]
+smtbmc
+
+[script]
+verific -vhdl subsub.vhd
+verific -vhdl sub.vhd
+verific -vhdl top.vhd
+hierarchy -top top
+hierarchy -top \\sub(p=41)\(rtl)
+
+[file top.vhd]
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity top is
+  port (
+    a : in integer
+  );
+end entity;
+
+architecture rtl of top is
+component sub is
+  generic (
+    p : integer
+  );
+  port (
+    a : in integer
+  );
+end component;
+begin
+  sub_i: sub
+    generic map (
+      p => 41
+    )
+    port map (
+      a => a
+    );
+end architecture;
+
+[file sub.vhd]
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity sub is
+  generic (
+    p : integer := 99
+  );
+  port (
+    a : in integer
+  );
+end entity;
+
+architecture rtl of sub is
+component subsub is
+  generic (
+    p : integer
+  );
+  port (
+    a : in integer
+  );
+end component;
+begin
+  subsub_i: subsub
+    generic map (
+      p => p + 1
+    )
+    port map (
+      a => a
+    );
+end architecture;
+
+[file subsub.vhd]
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity subsub is
+  generic (
+    p : integer := 99
+  );
+  port (
+    a : in integer
+  );
+end entity;
+
+architecture rtl of subsub is
+begin
+  assert (p > a);
+end architecture;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Since #298, top module names that have characters not allowed in solver format identifiers can't be resolved in property lookup as the mangled and unmangled module name are compared. (See the added test case for an example.)

_Explain how this is achieved._

Always mangle both sides in name comparisons.

_If applicable, please suggest to reviewers how they can test the change._

I'm not sure if the change in 154 is needed, it seems to work for submodules even before this, it only fails if it's the top module. To be honest I'm a bit confused why it works in the other case, but don't have time to track down what's happening. As long as the mangling doesn't further change already-mangled names this should be safe, but this is yet another unspoken assumption in an already-fragile construction...
