### PR TITLE
[docs] instruct to clone yosys with '--recurse-submodules'

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -63,7 +63,7 @@ Note that this will install Yosys, Yosys-SMTBMC and ABC (as ``yosys-abc``):
 
 .. code-block:: text
 
-   git clone https://github.com/YosysHQ/yosys
+   git clone https://github.com/YosysHQ/yosys --recurse-submodules
    cd yosys
    make -j$(nproc)
    sudo make install


### PR DESCRIPTION
Without using '--recurse-submodule', make fails to retrieve them before building.

_What are the reasons/motivation for this change?_

> To sum up, avoid quick failure of the `make -j$(nproc)` command.

Following the instructions at https://symbiyosys.readthedocs.io/en/latest/install.html

Invoking `make -j$(nproc)` did immediately failed because submodules were not retrieved. Here is the session I got : 

```
dsporn@Asusia:~/Projects/amaranth$ git clone https://github.com/YosysHQ/yosys
Clonage dans 'yosys'...
remote: Enumerating objects: 86268, done.
remote: Counting objects: 100% (2136/2136), done.
remote: Compressing objects: 100% (960/960), done.
remote: Total 86268 (delta 1426), reused 1763 (delta 1165), pack-reused 84132 (from 1)
Réception d'objets: 100% (86268/86268), 27.81 Mio | 1.69 Mio/s, fait.
Résolution des deltas: 100% (63475/63475), fait.
Mise à jour des fichiers: 100% (2619/2619), fait.


dsporn@Asusia:~/Projects/amaranth$ cd yosys/


dsporn@Asusia:~/Projects/amaranth/yosys (main =)$ make -j$(nproc)
[  0%] Building kernel/version_b89bd027a.cc
[  0%] Building kernel/driver.o
[  0%] Building techlibs/common/simlib_help.inc
Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule.
make: *** [Makefile:798 : check-git-abc] Erreur 1
make: *** Attente des tâches non terminées....
[  0%] Building techlibs/common/simcells_help.inc
kernel/driver.cc:22:10: fatal error: libs/cxxopts/include/cxxopts.hpp: Aucun fichier ou dossier de ce nom
   22 | #include "libs/cxxopts/include/cxxopts.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:758 : kernel/driver.o] Erreur 1
```

_Explain how this is achieved._

By instructing to clone the project using the switch `--recurse-submodules` ensure that all the submodules are in place when calling `make -j$(nproc)` 

```
dsporn@Asusia:~/Projects/amaranth$ git clone https://github.com/YosysHQ/yosys --recurse-submodules 
Clonage dans 'yosys'...
remote: Enumerating objects: 86268, done.
remote: Counting objects: 100% (2135/2135), done.
remote: Compressing objects: 100% (950/950), done.
remote: Total 86268 (delta 1428), reused 1771 (delta 1174), pack-reused 84133 (from 1)
Réception d'objets: 100% (86268/86268), 29.09 Mio | 1.69 Mio/s, fait.
Résolution des deltas: 100% (63553/63553), fait.
Mise à jour des fichiers: 100% (2619/2619), fait.
Sous-module 'abc' (https://github.com/YosysHQ/abc) enregistré pour le chemin 'abc'
Sous-module 'cxxopts' (https://github.com/jarro2783/cxxopts) enregistré pour le chemin 'libs/cxxopts'
Clonage dans '/home/dsporn/Projects/amaranth/yosys/abc'...
remote: Enumerating objects: 65969, done.        
remote: Counting objects: 100% (2297/2297), done.        
remote: Compressing objects: 100% (621/621), done.        
remote: Total 65969 (delta 1730), reused 2148 (delta 1666), pack-reused 63672 (from 1)        
Réception d'objets: 100% (65969/65969), 50.76 Mio | 1.69 Mio/s, fait.
Résolution des deltas: 100% (56328/56328), fait.
Clonage dans '/home/dsporn/Projects/amaranth/yosys/libs/cxxopts'...
remote: Enumerating objects: 1891, done.        
remote: Counting objects: 100% (226/226), done.        
remote: Compressing objects: 100% (52/52), done.        
remote: Total 1891 (delta 193), reused 178 (delta 174), pack-reused 1665 (from 1)        
Réception d'objets: 100% (1891/1891), 823.47 Kio | 1.65 Mio/s, fait.
Résolution des deltas: 100% (1113/1113), fait.
Chemin de sous-module 'abc' : 'cac8f99eaa220a5e3db5caeb87cef0a975c953a2' extrait
Chemin de sous-module 'libs/cxxopts' : '4bf61f08697b110d9e3991864650a405b3dd515d' extrait


dsporn@Asusia:~/Projects/amaranth$ cd yosys/


dsporn@Asusia:~/Projects/amaranth/yosys (main =)$ make -j$(nproc)
[  0%] Building kernel/version_b89bd027a.cc
[  0%] Building kernel/driver.o
[  0%] Building techlibs/common/simlib_help.inc
[  0%] Building techlibs/common/simcells_help.inc
[  1%] Building kernel/rtlil.o
[  1%] Building kernel/log.o
[  1%] Building kernel/calc.o
[  2%] Building kernel/yosys.o
[  2%] Building kernel/binding.o
[  2%] Building kernel/cellaigs.o
[  2%] Building kernel/celledges.o
kernel/calc.cc: In function ‘Yosys::RTLIL::Const Yosys::RTLIL::const_not(const Const&, const Const&, bool, bool, int)’:
...
...
... (snip awfully long build messages)
...
[ 94%] ABC: `` Compiling: /src/bdd/llb/llb4Cex.c
[ 94%] ABC: `` Compiling: /src/bdd/llb/llb4Image.c
[ 94%] ABC: `` Compiling: /src/bdd/llb/llb4Nonlin.c
[ 94%] ABC: `` Compiling: /src/bdd/llb/llb4Sweep.c
[ 94%] ABC: `` Building binary: abc
[100%] Building yosys-abc

  Build successful.

```

_If applicable, please suggest to reviewers how they can test the change._

In a temporary folder, with prerequisites installed

```
git clone https://github.com/YosysHQ/yosys --recurse-submodules
cd yosys
make -j$(nproc)
sudo make install
```