### PR TITLE
[docs] Fixes instructions for installing boolector

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -96,7 +96,7 @@ https://boolector.github.io
     ./configure.sh
     make -C build -j$(nproc)
     sudo cp build/bin/{boolector,btor*} /usr/local/bin/
-    sudo cp deps/btor2tools/bin/btorsim /usr/local/bin/
+    sudo cp deps/btor2tools/build/bin/btorsim /usr/local/bin/
 
 To use the ``btor`` engine you will need to install btor2tools from 
 `commit c35cf1c <https://github.com/Boolector/btor2tools/commit/c35cf1c>`_ or


### PR DESCRIPTION
There is a `build` folder where `bin\btorsim` is generated

_What are the reasons/motivation for this change?_

The given instruction fails : 

```
dsporn@Asusia:~/Projects/amaranth/boolector (master =)$ sudo cp deps/btor2tools/bin/btorsim /usr/local/bin/
cp: impossible d'évaluer 'deps/btor2tools/bin/btorsim': Aucun fichier ou dossier de ce nom
```

_Explain how this is achieved._

By fixing the path to copy from, the installation instructions for boolector complete without error.

_If applicable, please suggest to reviewers how they can test the change._

In a temporary folder, follows instructions to install Boolector from sources.