### PR TITLE
feat(sby_engine_aiger): add rIC3 support for BMC mode

### DIFF
--- a/sbysrc/sby_engine_aiger.py
+++ b/sbysrc/sby_engine_aiger.py
@@ -48,9 +48,13 @@ def run(mode, task, engine_idx, engine):
         solver_cmd = " ".join([task.exe_paths["avy"], "--cex", "-"] + solver_args[1:])
     
     elif solver_args[0] == "rIC3":
-        if mode != "prove":
-            task.error("The aiger solver 'rIC3' is only supported in prove mode.")
-        solver_cmd = " ".join([task.exe_paths["rIC3"], "--witness"] + solver_args[1:])
+        if mode not in ["bmc", "prove"]:
+            task.error("The aiger solver 'rIC3' is only supported in bmc and prove mode.")
+        if mode == "prove":
+            solver_cmd = " ".join([task.exe_paths["rIC3"], "--witness"] + solver_args[1:])
+        if mode == "bmc":
+            solver_cmd = " ".join([task.exe_paths["rIC3"], "--bmc-max-k {}".format(task.opt_depth - 1), "-e bmc", "-v 0", "--witness"] + solver_args[1:])
+            status_2 = "PASS"  # rIC3 outputs status 2 when BMC passes
 
     elif solver_args[0] == "aigbmc":
         if mode != "bmc":


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

- This change extends the functionality of the rIC3 solver in the sby_engine_aiger.py module to support BMC mode. Previously, rIC3 was only supported in prove mode, which limited its use cases. 

_Explain how this is achieved._

- the ric3 solver command is configured with specific BMC-related arguments, such as --bmc-max-k to define the maximum depth and -e bmc to enable BMC mode. Additionally, a status_2 variable is introduced to handle the BMC pass status output by rIC3.

_If applicable, please suggest to reviewers how they can test the change._

1. Running a BMC task using the rIC3 solver in a test environment.
2. Verifying that the solver correctly executes in BMC mode and produces the expected results.
3. Ensuring that the existing prove mode functionality remains unaffected.