### PR TITLE
allow running SBY tests with an external examples directory

### DIFF
--- a/docs/examples/Makefile
+++ b/docs/examples/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples
+SUBDIR=examples
 TESTDIR=../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/abstract/Makefile
+++ b/docs/examples/abstract/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/abstract
+SUBDIR=examples/abstract
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/demos/Makefile
+++ b/docs/examples/demos/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/demos
+SUBDIR=examples/demos
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/fifo/Makefile
+++ b/docs/examples/fifo/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/fifo
+SUBDIR=examples/fifo
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/indinv/Makefile
+++ b/docs/examples/indinv/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/indinv
+SUBDIR=examples/indinv
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/multiclk/Makefile
+++ b/docs/examples/multiclk/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/multiclk
+SUBDIR=examples/multiclk
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/puzzles/Makefile
+++ b/docs/examples/puzzles/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/puzzles
+SUBDIR=examples/puzzles
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/quickstart/Makefile
+++ b/docs/examples/quickstart/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/quickstart
+SUBDIR=examples/quickstart
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/docs/examples/tristate/Makefile
+++ b/docs/examples/tristate/Makefile
@@ -1,3 +1,3 @@
-SUBDIR=../docs/examples/tristate
+SUBDIR=examples/tristate
 TESTDIR=../../../tests
 include $(TESTDIR)/make/subdir.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,16 +24,28 @@ else
 SBY_MAIN := $(realpath $(dir $(firstword $(MAKEFILE_LIST)))/make/run_sby.py)
 endif
 
+ifeq ($(SBY_EXAMPLES),)
+EXAMPLE_DIR := ../docs/examples
+else
+EXAMPLE_DIR := $(SBY_EXAMPLES)
+endif
+
+CHECK_COLLECT := $(shell python3 make/collect_tests.py --check --output make/rules/collect.mk --examples $(EXAMPLE_DIR))
+ifneq (,$(CHECK_COLLECT))
+$(warning $(CHECK_COLLECT))
+endif
+
+
 ifeq (nt-unix-like,$(OS_NAME))
 SBY_MAIN := $(shell cygpath -w $(SBY_MAIN))
 endif
 export SBY_MAIN
 
 make/rules/collect.mk: make/collect_tests.py
-	python3 make/collect_tests.py
+	python3 make/collect_tests.py --output $@ --examples $(EXAMPLE_DIR)
 
 make/rules/test/%.mk:
-	python3 make/test_rules.py $<
+	python3 make/test_rules.py --rule $@ --source $<
 
 ifneq (help,$(MAKECMDGOALS))
 

--- a/tests/make/collect_tests.py
+++ b/tests/make/collect_tests.py
@@ -1,11 +1,32 @@
 from pathlib import Path
 import re
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--output", required=True)
+parser.add_argument("--examples")
+parser.add_argument("--check", action='store_true')
+args = parser.parse_args()
 
 tests = []
 checked_dirs = []
 
 SAFE_PATH = re.compile(r"^[a-zA-Z0-9_./\\]*$")
 
+out_file = Path(args.output)
+header_line = f"# example dir = {args.examples}"
+
+if args.check:
+    try:
+        with out_file.open("r") as f:
+            found_header = f.readline().strip()
+        if found_header != header_line:
+            out_file.unlink()
+    except FileNotFoundError:
+        pass
+    exit()
+
+out_file.parent.mkdir(exist_ok=True)
 
 def collect(path):
     # don't pick up any paths that need escaping nor any sby workdirs
@@ -13,6 +34,9 @@ def collect(path):
         not SAFE_PATH.match(str(path))
         or (path / "config.sby").exists()
         or (path / "status.sqlite").exists()
+        or (path / "config.mcy").exists()
+        or path.name == "__pycache__"
+        or path == out_file.parent
     ):
         return
 
@@ -24,6 +48,8 @@ def collect(path):
             continue
         if entry.name.startswith("skip_"):
             continue
+        if entry.with_suffix(".ivy").exists():
+            continue
         tests.append(entry)
     for entry in path.glob("*"):
         if entry.is_dir():
@@ -31,29 +57,41 @@ def collect(path):
 
 
 def unix_path(path):
-    return "/".join(path.parts)
+    source_path = "/".join(path.parts)
+    if source_path.startswith("//"):
+        source_path = source_path[1:]
+    if args.examples:
+        try:
+            relative = path.relative_to(args.examples)
+        except ValueError:
+            pass
+        else:
+            if '..' not in relative.parts:
+                return source_path, "examples/" + "/".join(relative.parts)
+    if '..' in path.parts:
+        raise RuntimeError("path escapes collect directories")
+    return source_path, source_path
 
 
-collect(Path("."))
-collect(Path("../docs/examples"))
-
-out_file = Path("make/rules/collect.mk")
-out_file.parent.mkdir(exist_ok=True)
+collect(Path('.'))
+if args.examples:
+    collect(Path(args.examples))
 
 with out_file.open("w") as output:
+    print(header_line, file=output)
 
     for checked_dir in checked_dirs:
         print(f"{out_file}: {checked_dir}", file=output)
 
     for test in tests:
-        test_unix = unix_path(test)
-        print(f"make/rules/test/{test_unix}.mk: {test_unix}", file=output)
+        test_unix_source, test_unix_rule = unix_path(test)
+        print(f"make/rules/test/{test_unix_rule}.mk: {test_unix_source}", file=output)
         for ext in [".sh", ".py"]:
             script_file = test.parent / (test.stem + ext)
             if script_file.exists():
-                script_file_unix = unix_path(script_file)
-                print(f"make/rules/test/{test_unix}.mk: {script_file_unix}", file=output)
-        print(f"make/rules/test/{test_unix}.mk: make/test_rules.py", file=output)
+                script_file_unix_source, script_file_unix_rule = unix_path(script_file)
+                print(f"make/rules/test/{test_unix_rule}.mk: {script_file_unix_source}", file=output)
+        print(f"make/rules/test/{test_unix_rule}.mk: make/test_rules.py", file=output)
     for test in tests:
-        test_unix = unix_path(test)
-        print(f"-include make/rules/test/{test_unix}.mk", file=output)
+        test_unix_source, test_unix_rule = unix_path(test)
+        print(f"-include make/rules/test/{test_unix_rule}.mk", file=output)

--- a/tests/make/subdir.mk
+++ b/tests/make/subdir.mk
@@ -5,6 +5,9 @@ test:
 
 .PHONY: test refresh IMPLICIT_PHONY
 
+Makefile: IMPLICIT_PHONY
+%.mk: IMPLICIT_PHONY
+
 IMPLICIT_PHONY:
 
 refresh:


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This allows testing the examples in their Tabby/OSS CAD install location to spot any missing relatively referenced files.

_Explain how this is achieved._

By adjusting the makefile and python scripts to support the SBY_EXAMPLES make variable in addition to the existing SBY_CMD variable. This required some refactoring in the test infrastructure to remove the assumptions of a fixed relative location of the examples directory.

_If applicable, please suggest to reviewers how they can test the change._

The following command fails for current tabby CAD due to a missing relative path

	make SBY_EXAMPLES=absolute_path_to/tabby/examples examples/demos/picorv32_axicheck

But in general running external examples should work e.g.

	make SBY_EXAMPLES=absolute_path_to/tabby/examples examples/fifo/test

