### PR TITLE
Improve database version handling and parallelism

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -22,7 +22,7 @@ import json, os, sys, shutil, tempfile, re
 from sby_cmdline import parser_func
 from sby_core import SbyConfig, SbyTask, SbyAbort, SbyTaskloop, process_filename, dress_message
 from sby_jobserver import SbyJobClient, process_jobserver_environment
-from sby_status import SbyStatusDb
+from sby_status import SbyStatusDb, remove_db, FileInUseError
 import time, platform, click
 
 release_version = 'unknown SBY version'
@@ -464,6 +464,12 @@ def start_task(taskloop, taskname):
                 print("*", file=gitignore)
         with open(f"{my_workdir}/status.path", "w") as status_path:
             print(my_status_db, file=status_path)
+        if os.path.exists(f"{my_workdir}/{my_status_db}") and opt_force:
+            try:
+                remove_db(f"{my_workdir}/{my_status_db}")
+            except FileInUseError:
+                # don't delete an open database
+                pass
 
     junit_ts_name = os.path.basename(sbyfile[:-4]) if sbyfile is not None else workdir if workdir is not None else "stdin"
     junit_tc_name = taskname if taskname is not None else "default"

--- a/sbysrc/sby_status.py
+++ b/sbysrc/sby_status.py
@@ -537,7 +537,35 @@ def filter_latest_task_ids(all_tasks: dict[int, dict[str]]):
 def remove_db(path):
     path = Path(path)
     lock_exts = [".sqlite-wal", ".sqlite-shm"]
+    maybe_locked = False
     for lock_file in [path.with_suffix(ext) for ext in lock_exts]:
         if lock_file.exists():
-            raise FileInUseError(file=lock_file)
-    os.remove(path)
+            # lock file may be a false positive if it wasn't cleaned up
+            maybe_locked = True
+            break
+
+    if not maybe_locked:
+        # safe to delete
+        os.remove(path)
+        return
+
+    # test database directly
+    with sqlite3.connect(path, isolation_level="EXCLUSIVE", timeout=1) as con:
+        cur = con.cursor()
+        # single result rows
+        cur.row_factory = lambda _, r: r[0]
+
+        # changing journal_mode is disallowed if there are multiple connections
+        try:
+            cur.execute("PRAGMA journal_mode=DELETE")
+        except sqlite3.OperationalError as err:
+            if "database is locked" in err.args[0]:
+                raise FileInUseError(file=path)
+            else:
+                raise
+
+        # no other connections, delete all tables
+        drop_script = cur.execute("SELECT name FROM sqlite_master WHERE type = 'table';").fetchall()
+        for table in drop_script:
+            print(table)
+            cur.execute(f"DROP TABLE {table}")

--- a/sbysrc/sby_status.py
+++ b/sbysrc/sby_status.py
@@ -100,6 +100,10 @@ def transaction(method: Fn) -> Fn:
 
     return wrapper  # type: ignore
 
+class FileInUseError(Exception):
+    def __init__(self, *args, file: Path|str = "file"):
+        super().__init__(f"Found {file}, try again later", *args)
+
 
 class SbyStatusDb:
     def __init__(self, path: Path, task, timeout: float = 5.0, live_csv = False):
@@ -529,3 +533,11 @@ def filter_latest_task_ids(all_tasks: dict[int, dict[str]]):
     for task_id, task_dict in all_tasks.items():
         latest[task_dict["workdir"]] = task_id
     return list(latest.values())
+
+def remove_db(path):
+    path = Path(path)
+    lock_exts = [".sqlite-wal", ".sqlite-shm"]
+    for lock_file in [path.with_suffix(ext) for ext in lock_exts]:
+        if lock_file.exists():
+            raise FileInUseError(file=lock_file)
+    os.remove(path)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Because the status db is persistent, if the schema of the existing database doesn't match the expected database, errors can occur.  e.g. trying to use #325 in a directory with a status database created by a different SBY version will crash because the database schema doesn't match.  

_Explain how this is achieved._

- Add a mechanism for testing the database schema (during `--status`), as well as resetting the database without requiring users to interact with the database directly (with `--statusreset`).
- Use a cursor for accessing the database, instead of calling `fetchone()` on `PRAGMA`s (this was #328).
- Improve safety of database setup step.
- Reset database automatically when running a task with `-f` if possible.

_If applicable, please suggest to reviewers how they can test the change._

Calling SBY with `--status` in a directory with a status database generated by a different version of SBY will return an error (at the very least because the whitespace in the create table queries has changed).  The additional `tests/statusdb/reset.sh` test should also run (and pass) on CI.