### PR TITLE
Output directory handling improvements

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -1039,8 +1039,9 @@ class SbyTask(SbyConfig):
         self.makedirs(outdir)
 
         for dstfile, lines in self.verbatim_files.items():
-            dstfile = self.workdir + "/src/" + dstfile
-            self.log(f"Writing '{dstfile}'.")
+            dstfile = outdir / dstfile
+            self.log(f"Writing '{dstfile.absolute()}'.")
+            dstfile.parent.mkdir(parents=True, exist_ok=True)
 
             with open(dstfile, "w") as f:
                 for line in lines:

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -579,7 +579,7 @@ class SbyConfig:
                     self.error(f"sby file syntax error: '[files]' section entry expects up to 2 arguments, {len(entries)} specified")
 
                 if len(entries) == 1:
-                    self.files[os.path.basename(entries[0])] = entries[0]
+                    self.files[Path(entries[0]).name] = entries[0]
                 elif len(entries) == 2:
                     self.files[entries[0]] = entries[1]
 

--- a/tests/links/more_dirs.sby
+++ b/tests/links/more_dirs.sby
@@ -1,0 +1,17 @@
+[tasks]
+link
+copy
+
+[options]
+mode prep
+
+[engines]
+btor btormc
+
+[script]
+read -noverific
+script dir/script.ys
+
+[files]
+here/dir ${WORKDIR}/../dir
+a/b/c.v prv32fmcmp.v

--- a/tests/links/more_dirs.sby
+++ b/tests/links/more_dirs.sby
@@ -15,3 +15,6 @@ script dir/script.ys
 [files]
 here/dir ${WORKDIR}/../dir
 a/b/c.v prv32fmcmp.v
+
+[file here/doc]
+log foo

--- a/tests/links/more_dirs.sh
+++ b/tests/links/more_dirs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+if [[ $TASK == link ]]; then
+    flags="--setup --link"
+else
+    flags="--setup"
+fi
+python3 $SBY_MAIN -f $SBY_FILE $TASK $flags
+
+test -e ${WORKDIR}/src/here/dir -a -e ${WORKDIR}/src/a/b/c.v

--- a/tests/links/more_dirs.sh
+++ b/tests/links/more_dirs.sh
@@ -7,4 +7,4 @@ else
 fi
 python3 $SBY_MAIN -f $SBY_FILE $TASK $flags
 
-test -e ${WORKDIR}/src/here/dir -a -e ${WORKDIR}/src/a/b/c.v
+test -e ${WORKDIR}/src/here/dir -a -e ${WORKDIR}/src/a/b/c.v -a -e ${WORKDIR}/src/here/doc

--- a/tests/links/symlink.py
+++ b/tests/links/symlink.py
@@ -4,6 +4,7 @@ import sys
 def main():
     workdir, task = sys.argv[1:]
     src = Path(workdir) / "src"
+    count = 0
     for srcfile in src.iterdir():
         if srcfile.name == "heredoc":
             assert(not srcfile.is_symlink())
@@ -13,6 +14,10 @@ def main():
         else:
             assert(srcfile.is_symlink() == (task == "link"))
             assert(srcfile.name != "script.ys")
+        count += 1
+    assert(count == 4)
+    script_ys = src / "dir" / "script.ys"
+    assert(script_ys.exists())
 
 if __name__ == "__main__":
     main()

--- a/tests/links/symlink.py
+++ b/tests/links/symlink.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import sys
 
@@ -13,6 +12,7 @@ def main():
                 assert(local_contents.strip() == 'log foo')
         else:
             assert(srcfile.is_symlink() == (task == "link"))
+            assert(srcfile.name != "script.ys")
 
 if __name__ == "__main__":
     main()

--- a/tests/links/symlink.sby
+++ b/tests/links/symlink.sby
@@ -1,6 +1,8 @@
 [tasks]
 link
 copy
+dir_implicit: dir
+dir_explicit: dir
 
 [options]
 mode prep
@@ -15,7 +17,9 @@ script dir/script.ys
 [files]
 ../../docs/examples/demos/picorv32.v
 prv32fmcmp.v
-dir
+~dir: dir
+dir_implicit: dir/
+dir_explicit: dir/ dir/
 
 [file heredoc]
 log foo


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

SBY uses `os.path.basename()` as the target destination in the `[files]` section.  This means that if a directory is given as `/path/to/dir` the destination is `<workdir>/src/dir`, but if it is given as `/path/to/dir/` the destination instead becomes `<workdir>/src`.  

_Explain how this is achieved._

`Path.name` also gives the basename component, but doesn't return an empty string when there is a trailing slash.  Since we're using `pathlib.Path` for some things we should replace the other `os.path` uses too (except `os.path.expandvars()` because there isn't an equivalent method for `pathlib.Path`)

While testing that the changes were equivalent I also noticed that heredocs weren't allowed to have directories in their path, so I fixed that.

Hopefully nobody was relying on the behaviour to copy a directories contents into the root, but it may be worth adding a note to the docs that you can accomplish this with an explicit `. /path/to/dir/` in `[files]`?

_If applicable, please suggest to reviewers how they can test the change._

|Tests from commit | main branch | PR behaviour |
|----|----|-----|
|a906714 | fail | pass |
|1d28294 | pass | pass |
|5fffe7e | fail | pass |