### PR TITLE
Fix exception when running abc without properties

### DIFF
--- a/sbysrc/sby_engine_abc.py
+++ b/sbysrc/sby_engine_abc.py
@@ -246,6 +246,9 @@ def run(mode, task, engine_idx, engine):
                 else:
                     proc_status = "FAIL"
 
+        match = re.match("Error: (Does not work|Only works) for (sequential|combinational) networks.", line)
+        if match: proc_status = "ERROR"
+
         return line
 
     def exit_callback(retcode):

--- a/sbysrc/sby_engine_abc.py
+++ b/sbysrc/sby_engine_abc.py
@@ -203,7 +203,7 @@ def run(mode, task, engine_idx, engine):
         match = re.match(r"^Proved output +([0-9]+) in frame +-?[0-9]+", line)
         if match:
             output = int(match[1])
-            prop = aiger_props[output]
+            prop = aiger_props[output] if aiger_props else None
             if prop:
                 prop.status = "PASS"
                 task.summary.add_event(
@@ -232,7 +232,7 @@ def run(mode, task, engine_idx, engine):
                 disproved_count = int(match[3])
                 undecided_count = int(match[4])
                 if (
-                    all_count != len(aiger_props) or
+                    (aiger_props and all_count != len(aiger_props)) or
                     all_count != proved_count + disproved_count + undecided_count or
                     disproved_count != len(disproved) or
                     proved_count != len(proved)

--- a/tests/unsorted/no_props.sby
+++ b/tests/unsorted/no_props.sby
@@ -1,13 +1,26 @@
 [tasks]
-abc
-abc_keepgoing
+abc prove
+abc_keepgoing prove
+
+# "Error: Does not work for combinational networks."
+abc_bmc3 bmc error
+# "Error: Only works for sequential networks."
+abc_sim3 bmc error
+# "Property index 0 is greater than the number of properties in file model/design_btor_single.btor (0)"
+btor_pono bmc error
 
 [options]
-mode prove
+prove: mode prove
+bmc: mode bmc
+cover: mode cover
+error: expect ERROR
 
 [engines]
 abc: abc pdr
 abc_keepgoing: abc --keep-going pdr
+btor_pono: btor pono
+abc_bmc3: abc bmc3
+abc_sim3: abc sim3
 
 [script]
 read -sv test.sv

--- a/tests/unsorted/no_props.sby
+++ b/tests/unsorted/no_props.sby
@@ -1,0 +1,21 @@
+[tasks]
+abc
+abc_keepgoing
+
+[options]
+mode prove
+
+[engines]
+abc: abc pdr
+abc_keepgoing: abc --keep-going pdr
+
+[script]
+read -sv test.sv
+prep -top top
+
+[file test.sv]
+module top(input i, output o);
+
+assign o = ~i;
+
+endmodule


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #338 

_Explain how this is achieved._

ABC proves one (trivial) property even if `aiger_props` is empty, but we should only try matching to `aiger_props` if it is not empty (including checking the property count).

There were also a couple of unhandled errors when running the BMC solvers in ABC which ended up with a status of `UNKNOWN` that now return `ERROR` instead.

_If applicable, please suggest to reviewers how they can test the change._

Add empty `prove`, `cover`, and `bmc` tasks to `no_props.sby`.  Run `sby --autotune -f no_props.sby [prove|cover|bmc]`.  There should not be any engines which raise an exception, and all failing engines should already have tasks which `expect ERROR` set.
