### PR TITLE
fix: print Path as string

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -365,7 +365,7 @@ if dump_files:
             find_files(taskname)
     else:
         find_files(None)
-    print("\n".join(file_set))
+    print("\n".join(str(f) for f in file_set))
     sys.exit(0)
 
 if dump_tags:


### PR DESCRIPTION
https://github.com/YosysHQ/sby/commit/ac419190d2e14b18b3e664a22e73232ef38e6b47 broke dump_files. This commit fixes it, by casting Path objects to string before printing.