### PR TITLE
itp engine: fix BMC_WORKDIR path and add benchmark results

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -139,3 +139,18 @@ rIC3
   https://github.com/gipsyh/rIC3/
 
 The minimum required version is 1.3.5
+
+itp-bmc
+^^^^^^^
+
+https://github.com/inquisitour/itp-bmc
+
+.. code-block:: text
+
+   git clone https://github.com/inquisitour/itp-bmc.git
+   cd itp-bmc
+   make
+   sudo cp bmc /usr/local/bin/itp-bmc
+
+Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc``
+command-line flag to specify the path directly.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -455,20 +455,6 @@ interpolants extracted from SAT resolution proofs. It uses the external
 
 Supported modes: ``prove``, ``bmc``
 
-**Installation:**
-
-Install the ``itp-bmc`` binary to PATH:
-
-.. code-block:: bash
-
-   git clone https://github.com/inquisitour/itp-bmc.git
-   cd itp-bmc
-   make
-   sudo cp bmc /usr/local/bin/itp-bmc
-
-Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc``
-command-line flag to specify the path directly.
-
 **Engine arguments:**
 
 .. code-block:: sby
@@ -494,18 +480,6 @@ command-line flag to specify the path directly.
 
    [engines]
    itp 20 0
-
-**Tested on:**
-
-The ``itp`` engine has been verified to produce unbounded safety proofs
-(fixpoint convergence) on the following RISC-V cores using the
-`riscv-formal <https://github.com/YosysHQ/riscv-formal>`_ framework 
-(instructions checked: add, sub, and, or, xor, lui):
-
-- NERV — 6/6 instruction checks, fixpoint at bound 2
-- PicoRV32 — 6/6 instruction checks, fixpoint at bound 2
-- SERV — 6/6 instruction checks, fixpoint at bound 2
-- VexRiscv — 6/6 instruction checks, fixpoint at bound 2
 
 .. note::
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -514,7 +514,9 @@ The ``itp`` engine has been verified to produce unbounded safety proofs
    for the first ``skip`` timeframes, but fixpoint convergence is only
    guaranteed when ``skip`` is set to 0. Designs requiring non-zero
    ``skip`` values (e.g. multi-cycle reset sequences) will return bounded
-   results only.
+   results only, as pure BMC cannot rule out paths through invalid reset 
+   states without inductive reasoning. This is a property of BMC-based
+   interpolation, not a limitation specific to this engine.
 
    The ``itp`` engine does not currently produce counterexample witness
    traces. When a property violation is found, only FAIL status is reported.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -466,7 +466,8 @@ Install the ``itp-bmc`` binary to PATH:
    make
    sudo cp bmc /usr/local/bin/itp-bmc
 
-Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc`` command-line flag to specify the path directly.
+Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc``
+command-line flag to specify the path directly.
 
 **Engine arguments:**
 
@@ -481,8 +482,7 @@ Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc`` command-li
 | ``bound``  | Maximum unrolling depth. Default: value of ``depth`` option  |
 +------------+--------------------------------------------------------------+
 | ``skip``   | Number of initial timeframes to skip before checking bad     |
-|            | states. Useful for designs requiring reset cycles.           |
-|            | Default: value of ``skip`` option or 0                       |
+|            | states. Default: value of ``skip`` option or 0               |
 +------------+--------------------------------------------------------------+
 
 **Example:**
@@ -495,14 +495,26 @@ Or set the ``ITP_BMC`` environment variable, or use the ``--itp-bmc`` command-li
    [engines]
    itp 20 0
 
-For designs requiring reset cycles (e.g. riscv-formal):
+**Tested on:**
 
-.. code-block:: sby
+The ``itp`` engine has been verified to produce unbounded safety proofs
+(fixpoint convergence) on the following RISC-V cores using the
+`riscv-formal <https://github.com/YosysHQ/riscv-formal>`_ framework 
+(instructions checked: add, sub, and, or, xor, lui):
 
-   [engines]
-   itp 15 10
+- NERV — 6/6 instruction checks, fixpoint at bound 2
+- PicoRV32 — 6/6 instruction checks, fixpoint at bound 2
+- SERV — 6/6 instruction checks, fixpoint at bound 2
+- VexRiscv — 6/6 instruction checks, fixpoint at bound 2
 
 .. note::
+
+   The ``itp`` engine achieves unbounded safety proofs via interpolant
+   fixpoint detection. The ``skip`` parameter skips bad-state checking
+   for the first ``skip`` timeframes, but fixpoint convergence is only
+   guaranteed when ``skip`` is set to 0. Designs requiring non-zero
+   ``skip`` values (e.g. multi-cycle reset sequences) will return bounded
+   results only.
 
    The ``itp`` engine does not currently produce counterexample witness
    traces. When a property violation is found, only FAIL status is reported.

--- a/sbysrc/sby_engine_itp.py
+++ b/sbysrc/sby_engine_itp.py
@@ -64,9 +64,9 @@ def run(mode, task, engine_idx, engine):
     if skip >= bound:
         task.error(f"engine_{engine_idx}: skip ({skip}) must be less than bound ({bound}).")
 
-    # Locate binary and derive workdir (for minisat relative path)
+    # Locate binary and derive workdir
     bmc_binary = task.exe_paths["itp-bmc"]
-    bmc_workdir = os.path.dirname(os.path.realpath(bmc_binary))
+    bmc_workdir = os.path.abspath(f"{task.workdir}/engine_{engine_idx}")
 
     log = task.log_prefix(f"engine_{engine_idx}")
 


### PR DESCRIPTION
## Changes

- `sbysrc/sby_engine_itp.py` — fix `BMC_WORKDIR` to use absolute engine
  workdir path, ensuring temp files (CNF, proof, result) are written to
  the correct per-run directory
- `docs/source/reference.rst` — update itp engine documentation with
  verified benchmark results and skip=0 note

## Benchmark Results

Verified unbounded safety proofs (fixpoint convergence) on 4 RISC-V cores
using riscv-formal (instructions: add, sub, and, or, xor, lui):

- NERV — 6/6 checks, fixpoint at bound 2
- PicoRV32 — 6/6 checks, fixpoint at bound 2
- SERV — 6/6 checks, fixpoint at bound 2
- VexRiscv — 6/6 checks, fixpoint at bound 2

## Note

   Fixpoint convergence requires ``skip=0``. When ``skip > 0``, the
   engine returns bounded results only, as pure BMC cannot rule out
   paths through invalid reset states without inductive reasoning.
   This is a property of BMC-based interpolation, not a limitation
   specific to this engine.