### PR TITLE
fix: reject Windows drive path task conflicts

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -224,6 +224,16 @@ def read_sbyconfig(sbydata, taskname):
             found_task_tag = False
             task_skip_line = False
 
+            windows_drive_path = re.match(r"^([A-Za-z]):[\\/]", line)
+            if windows_drive_path and windows_drive_path.group(1) in task_tags_all:
+                drive = windows_drive_path.group(1)
+                print(
+                    f'ERROR: Task or group name "{drive}" conflicts with Windows path "{line}". '
+                    "Rename the task or group.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
             for t in task_tags_all:
                 if line.startswith(t+":"):
                     line = line[len(t)+1:].lstrip()

--- a/tests/config_parser/windows_drive_task_names.py
+++ b/tests/config_parser/windows_drive_task_names.py
@@ -1,0 +1,57 @@
+import subprocess
+import sys
+
+
+def run_sby(sby_main, config):
+    return subprocess.run(
+        [sys.executable, sby_main, "--dumptasks"],
+        input=config,
+        capture_output=True,
+        text=True,
+    )
+
+
+def expect_drive_conflict(sby_main, tasks, drive_path):
+    result = run_sby(
+        sby_main,
+        f"""[tasks]
+{tasks}
+
+[options]
+mode prep
+
+[files]
+{drive_path}
+""",
+    )
+
+    drive = drive_path[0]
+    expected = (
+        f'ERROR: Task or group name "{drive}" conflicts with Windows path '
+        f'"{drive_path}". Rename the task or group.'
+    )
+    assert result.returncode == 1, result
+    assert expected in result.stderr, result.stderr
+
+
+def main():
+    sby_main = sys.argv[1]
+
+    expect_drive_conflict(sby_main, "C", r"C:\src\example.sv")
+    expect_drive_conflict(sby_main, "task D", "D:/src/example.sv")
+
+    result = run_sby(
+        sby_main,
+        """[tasks]
+C
+
+[options]
+C: mode prep
+""",
+    )
+    assert result.returncode == 0, result
+    assert "C" in result.stdout.splitlines(), result.stdout
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config_parser/windows_drive_task_names.sby
+++ b/tests/config_parser/windows_drive_task_names.sby
@@ -1,0 +1,2 @@
+[options]
+mode prep

--- a/tests/config_parser/windows_drive_task_names.sh
+++ b/tests/config_parser/windows_drive_task_names.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+python3 windows_drive_task_names.py "$SBY_MAIN"


### PR DESCRIPTION
## Summary

- detect absolute Windows drive paths before task/tag prefix handling
- report a clear error when a drive letter conflicts with a task or group name
- add regression coverage for `C:\\...`, `D:/...`, group aliases, and ordinary one-letter task conditionals

Fixes #162.

## Root cause

Task and tag parsing happens before section parsing. When a task or group named `C` exists, a file line beginning with `C:\\` is interpreted as the `C:` task prefix and is stripped or skipped instead of being retained as a path.

This keeps the workaround small ahead of the planned parser migration: ambiguous drive-path lines now fail with a diagnostic asking the user to rename the conflicting task or group.

## Validation

- `python tests/config_parser/windows_drive_task_names.py sbysrc/sby.py`
- `python -m py_compile sbysrc/sby.py tests/config_parser/windows_drive_task_names.py`
- `git diff --check`
- broad test-matrix execution with OSS CAD Suite 2026-07-20

The complete matrix is not green on native Windows because of unrelated existing platform/tool limitations, including child-solver cancellation, symlink privileges, POSIX-only path assertions, and unavailable or crashing AIG engines. The focused regression and ordinary parser/solver paths pass.
